### PR TITLE
Error CSS styling for hosted field inputs

### DIFF
--- a/public/minimal/style.css
+++ b/public/minimal/style.css
@@ -78,6 +78,10 @@ input.error {
   border-color: #e43c29;
 }
 
+div.error .recurly-hosted-field {
+  border: 2px solid #e43c29;
+}
+
 div.date {
   display: inline-block;
   width: 4.5rem;


### PR DESCRIPTION
This will properly add a red border around the hosted field inputs in the minimal example.